### PR TITLE
Hi Mitch, saw this bug and was affected by it myself.  Figured a quick fix would resolve a few things on your tracker and would fix it for myself.  Cheers!

### DIFF
--- a/src/main/java/com/mtihc/minecraft/treasurechest/Permission.java
+++ b/src/main/java/com/mtihc/minecraft/treasurechest/Permission.java
@@ -3,7 +3,7 @@ package com.mtihc.minecraft.treasurechest;
 public enum Permission {
 	MAIN("treasurechest"),
 	SET("treasurechest.set"),
-	DEL("treasurechest.del"),
+	DEL("treasurechest.delete"),
 	FORGET("treasurechest.forget"),
 	FORGET_OTHERS("treasurechest.forget.others"),
 	FORGET_ALL("treasurechest.forget.all"),


### PR DESCRIPTION
file.  Changed the "treasurechest.del" permission back to
"treasurechest.delete" to maintain consistency back with the application
and the existing documentation.
