### PR TITLE
set access.treasure & access.unlimited permissions to be true by default

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -73,10 +73,10 @@ permissions:
             treasurechest.access.unlimited: true
     treasurechest.access.treasure:
         description: Allows opening treasure chests
-        default: false
+        default: true
     treasurechest.access.unlimited:
         description: Allows opening unlimited chests
-        default: false
+        default: true
     
     treasurechest.count:
         description: Allows you to count how many chests you have found


### PR DESCRIPTION
I set the default for _treasurechest.access.treasure_ and _treasurechest.access.unlimited_  to be set as true by default. These permissions need to be set to true so regular players can open treasure chests.
