### PR TITLE
Update for 1.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.mtihc.minecraft.treasurechest.v8.plugin</groupId>
 	<artifactId>TreasureChest</artifactId>
-	<version>8.5.0</version>
+	<version>8.5.1</version>
 	<name>TreasureChest</name>
 	<url>http://dev.bukkit.org/server-mods/treasurechest/</url>
 	<repositories>
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>org.bukkit</groupId>
 			<artifactId>bukkit</artifactId>
-			<version>1.7.10-R0.1-SNAPSHOT</version>
+			<version>1.9.2-R0.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sk89q</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.mtihc.minecraft.treasurechest.v8.plugin</groupId>
 	<artifactId>TreasureChest</artifactId>
-	<version>8.4.4</version>
+	<version>8.5.0</version>
 	<name>TreasureChest</name>
 	<url>http://dev.bukkit.org/server-mods/treasurechest/</url>
 	<repositories>
@@ -17,7 +17,7 @@
 		</repository>
 		<repository>
 			<id>milkbowl-repo</id>
-			<url>http://ci.milkbowl.net/plugin/repository/everything/</url>
+			<url>http://nexus.theyeticave.net/content/repositories/pub_releases</url>
 		</repository>
 	</repositories>
 	<build>
@@ -37,17 +37,17 @@
 		<dependency>
 			<groupId>org.bukkit</groupId>
 			<artifactId>bukkit</artifactId>
-			<version>1.6.2-R0.1-SNAPSHOT</version>
+			<version>1.7.10-R0.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sk89q</groupId>
 			<artifactId>worldedit</artifactId>
-			<version>5.5.8-SNAPSHOT</version>
+			<version>6.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>net.milkbowl.vault</groupId>
 			<artifactId>Vault</artifactId>
-			<version>1.2.27</version>
+			<version>1.5.6</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.mtihc.minecraft.treasurechest.v8.plugin</groupId>
 	<artifactId>TreasureChest</artifactId>
-	<version>8.5.1</version>
+	<version>8.4.4</version>
 	<name>TreasureChest</name>
 	<url>http://dev.bukkit.org/server-mods/treasurechest/</url>
 	<repositories>

--- a/src/main/java/com/mtihc/minecraft/treasurechest/v8/util/prompts/SelectRegionPrompt.java
+++ b/src/main/java/com/mtihc/minecraft/treasurechest/v8/util/prompts/SelectRegionPrompt.java
@@ -1,7 +1,10 @@
 package com.mtihc.minecraft.treasurechest.v8.util.prompts;
 
+import java.util.Set;
+
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.command.CommandSender;
@@ -157,7 +160,7 @@ public abstract class SelectRegionPrompt extends ValidatingPrompt {
 	}
 
 	private Block getTargetBlock(Player player) {
-		Block block = player.getTargetBlock(null, 8);
+		Block block = player.getTargetBlock((Set<Material>) null, 8);
 		if (block == null || block.getTypeId() == 0) {
 			return null;
 		}


### PR DESCRIPTION
Updating dependencies and repo for Vault.
Making the use of getTargetBlock compatible with Bukkit 1.9